### PR TITLE
Yourls 1.7 compatibility fix

### DIFF
--- a/plugins/apc-cache/plugin.php
+++ b/plugins/apc-cache/plugin.php
@@ -22,6 +22,7 @@ if(!defined('APC_READ_CACHE_TIMEOUT')) {
 define('APC_CACHE_LOG_INDEX', 'cachelogindex');
 define('APC_CACHE_LOG_TIMER', 'cachelogtimer');
 define('APC_CACHE_ALL_OPTIONS', 'cache-get_all_options');
+define('APC_CACHE_INSTALLED', 'cache-installed');
 if(!defined('APC_CACHE_LONG_TIMEOUT')) {
 	define('APC_CACHE_LONG_TIMEOUT', 86400);
 }
@@ -50,6 +51,7 @@ function apc_cache_shunt_all_options($false) {
 	$key = APC_CACHE_ALL_OPTIONS; 
 	if(apc_exists($key)) {
 		$ydb->option = apc_fetch($key);
+		$ydb->installed = apc_fetch(APC_CACHE_INSTALLED);
 		return true;
 	} 
 	
@@ -64,6 +66,7 @@ function apc_cache_shunt_all_options($false) {
  */
 function apc_cache_get_all_options($option) {
 	apc_store(APC_CACHE_ALL_OPTIONS, $option, APC_READ_CACHE_TIMEOUT);
+	apc_store(APC_CACHE_INSTALLED, true, APC_READ_CACHE_TIMEOUT);
 	return $option;
 }
 

--- a/plugins/apc-cache/plugin.php
+++ b/plugins/apc-cache/plugin.php
@@ -22,7 +22,7 @@ if(!defined('APC_READ_CACHE_TIMEOUT')) {
 define('APC_CACHE_LOG_INDEX', 'cachelogindex');
 define('APC_CACHE_LOG_TIMER', 'cachelogtimer');
 define('APC_CACHE_ALL_OPTIONS', 'cache-get_all_options');
-define('APC_CACHE_INSTALLED', 'cache-installed');
+define('APC_CACHE_YOURLS_INSTALLED', 'cache-yourls_installed');
 if(!defined('APC_CACHE_LONG_TIMEOUT')) {
 	define('APC_CACHE_LONG_TIMEOUT', 86400);
 }
@@ -51,7 +51,7 @@ function apc_cache_shunt_all_options($false) {
 	$key = APC_CACHE_ALL_OPTIONS; 
 	if(apc_exists($key)) {
 		$ydb->option = apc_fetch($key);
-		$ydb->installed = apc_fetch(APC_CACHE_INSTALLED);
+		$ydb->installed = apc_fetch(APC_CACHE_YOURLS_INSTALLED);
 		return true;
 	} 
 	
@@ -66,7 +66,8 @@ function apc_cache_shunt_all_options($false) {
  */
 function apc_cache_get_all_options($option) {
 	apc_store(APC_CACHE_ALL_OPTIONS, $option, APC_READ_CACHE_TIMEOUT);
-	apc_store(APC_CACHE_INSTALLED, true, APC_READ_CACHE_TIMEOUT);
+        // Set timeout on installed property twice as long as the options as otherwise there could be a split second gap
+	apc_store(APC_CACHE_YOURLS_INSTALLED, true, (2 * APC_READ_CACHE_TIMEOUT));
 	return $option;
 }
 


### PR DESCRIPTION
This will fix the compatibility with the Yourls 1.7 release:
1. installed property is now stored in APC when options are stored (timeout twice as long as the options)
2. installed property is retrieved from APC on while reading the options
